### PR TITLE
feat(morpho): monitor Steakhouse Confidential Prime USDC V2 vault

### DIFF
--- a/protocols/morpho/config.py
+++ b/protocols/morpho/config.py
@@ -72,6 +72,7 @@ VAULTS_V2_BY_CHAIN: dict[Chain, tuple[VaultConfig, ...]] = {
         VaultConfig("Yearn OG USDC", "0xB885F6d448dA7E2C642Ec31190B629E40E87B069", 3),
         VaultConfig("Sentora RLUSD Main", "0x6dC58a0FdfC8D694e571DC59B9A52EEEa780E6bf", 2),
         VaultConfig("Sentora PaypalUSD Main", "0xb576765fB15505433aF24FEe2c0325895C559FB2", 2),
+        VaultConfig("Steakhouse Confidential Prime USDC", "0xbEEF00A59B577423653A1526c7009bdE103F542B", 1),
     ),
     Chain.BASE: (
         VaultConfig("Yearn OG USDC V2", "0xe7D0DBE3493830e2Ab62619211A2BfF0Fc60dB42", 2),


### PR DESCRIPTION
Adds monitoring for the [Steakhouse Confidential Prime USDC](https://app.morpho.org/ethereum/vault/0xbEEF00A59B577423653A1526c7009bdE103F542B/steakhouse-confidential-prime-usdc#overview) Morpho V2 vault on Ethereum (risk level 1).

- Appends the vault to `VAULTS_V2_BY_CHAIN[Chain.MAINNET]` in `protocols/morpho/config.py`, which enables both hourly market/risk/liquidity monitoring (`markets_v2.py`) and daily governance monitoring (`governance_v2.py`).
- All three vault markets (cbBTC/USDC ~98.7%, WETH/USDC ~1.3%, wstETH/USDC dust) are classified `MARKETS_RISK_1`, so risk level 1 is appropriate.
- Verified discovery via the Morpho GraphQL API (TVL \$34.4M).