### PR TITLE
fix(llm): truncate token hints to whole amounts

### DIFF
--- a/tests/test_llm_report.py
+++ b/tests/test_llm_report.py
@@ -227,9 +227,10 @@ class TestAmountAnnotation(unittest.TestCase):
         flow = self._flow([("uint256", 43), ("uint256", 5369214230155537376952673)], None)
         self.assertNotIn("≈", flow)
 
-    def test_sub_token_amount_not_annotated(self) -> None:
+    def test_sub_token_amount_keeps_one_truncated_decimal(self) -> None:
         usdc = RelatedToken(getter="self", address=REGISTRY, symbol="USDC", decimals=6)
-        self.assertNotIn("≈", self._flow([("uint256", 999_999)], usdc))
+        self.assertIn("(≈ 0.5 USDC)", self._flow([("uint256", 590_000)], usdc))
+        self.assertNotIn("≈", self._flow([("uint256", 99_999)], usdc))
         self.assertIn("(≈ 1 USDC)", self._flow([("uint256", 1_000_000)], usdc))
 
     def test_non_uint_types_untouched(self) -> None:

--- a/tests/test_llm_report.py
+++ b/tests/test_llm_report.py
@@ -215,8 +215,8 @@ class TestAmountAnnotation(unittest.TestCase):
         return format_call_flow(_add_farms_ctx(entries=[entry]))
 
     def test_large_uint_annotated(self) -> None:
-        flow = self._flow([("uint256", 43), ("uint256", 5369214230155537376952673)], self.JANE)
-        self.assertIn("`5,369,214,230,155,537,376,952,673` (≈ 5,369,214.230155537376952673 JANE)", flow)
+        flow = self._flow([("uint256", 43), ("uint256", 5499673832374850402183062)], self.JANE)
+        self.assertIn("`5,499,673,832,374,850,402,183,062` (≈ 5,499,673 JANE)", flow)
 
     def test_small_uint_not_annotated(self) -> None:
         """An epoch number must not be rendered as 0.000000000000000043 JANE."""
@@ -227,10 +227,10 @@ class TestAmountAnnotation(unittest.TestCase):
         flow = self._flow([("uint256", 43), ("uint256", 5369214230155537376952673)], None)
         self.assertNotIn("≈", flow)
 
-    def test_threshold_is_one_thousandth_of_a_token(self) -> None:
+    def test_sub_token_amount_not_annotated(self) -> None:
         usdc = RelatedToken(getter="self", address=REGISTRY, symbol="USDC", decimals=6)
-        self.assertIn("(≈ 0.001 USDC)", self._flow([("uint256", 1000)], usdc))
-        self.assertNotIn("≈", self._flow([("uint256", 999)], usdc))
+        self.assertNotIn("≈", self._flow([("uint256", 999_999)], usdc))
+        self.assertIn("(≈ 1 USDC)", self._flow([("uint256", 1_000_000)], usdc))
 
     def test_non_uint_types_untouched(self) -> None:
         call = DecodedCall(function_name="setRoot", signature="setRoot(bytes32)", params=[("bytes32", b"\\x01" * 32)])

--- a/utils/llm/report.py
+++ b/utils/llm/report.py
@@ -123,19 +123,24 @@ def format_address_links_block(addresses: list[str], chain_id: int, labels: dict
 def _amount_hint(type_str: str, value: object, token: RelatedToken | None) -> str:
     """Human-readable suffix for a raw token amount, or "" when it doesn't apply.
 
-    Only annotates values of at least one whole token. Without that floor every
-    small integer picks up a nonsense hint — an epoch number like ``43`` would
-    render as ``0 JANE``. Fractional tokens are truncated so the call flow stays
-    concise.
+    Whole-token values are truncated to an integer. Values from 0.1 to under 1
+    token retain one truncated decimal place; smaller values are left unannotated
+    so they never render as a misleading ``0.0 TOKEN`` hint.
     """
     if token is None or not type_str.startswith("uint"):
         return ""
     if not isinstance(value, int) or isinstance(value, bool):
         return ""
-    whole_tokens = value // (10**token.decimals)
-    if whole_tokens < 1:
-        return ""
-    return f" (≈ {whole_tokens:,} {token.symbol})"
+    token_scale = 10**token.decimals
+    whole_tokens = value // token_scale
+    if whole_tokens >= 1:
+        amount = f"{whole_tokens:,}"
+    else:
+        tenths = (value * 10) // token_scale
+        if tenths < 1:
+            return ""
+        amount = f"0.{tenths}"
+    return f" (≈ {amount} {token.symbol})"
 
 
 def _format_param_value(

--- a/utils/llm/report.py
+++ b/utils/llm/report.py
@@ -24,7 +24,6 @@ from utils.calldata.decoder import (
     try_decode_inner_calldata,
 )
 from utils.chains import EXPLORER_URLS, Chain
-from utils.formatting import format_decimal_amount, normalize_token_amount
 from utils.related_tokens import RelatedToken
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
@@ -124,16 +123,19 @@ def format_address_links_block(addresses: list[str], chain_id: int, labels: dict
 def _amount_hint(type_str: str, value: object, token: RelatedToken | None) -> str:
     """Human-readable suffix for a raw token amount, or "" when it doesn't apply.
 
-    Only annotates unsigned integers large enough to plausibly be an amount
-    (≥0.001 of the token). Without that floor every small integer picks up a
-    nonsense hint — an epoch number like ``43`` would render as
-    ``0.000000000000000043 JANE``.
+    Only annotates values of at least one whole token. Without that floor every
+    small integer picks up a nonsense hint — an epoch number like ``43`` would
+    render as ``0 JANE``. Fractional tokens are truncated so the call flow stays
+    concise.
     """
     if token is None or not type_str.startswith("uint"):
         return ""
-    if not isinstance(value, int) or isinstance(value, bool) or value < 10 ** max(token.decimals - 3, 0):
+    if not isinstance(value, int) or isinstance(value, bool):
         return ""
-    return f" (≈ {format_decimal_amount(normalize_token_amount(value, token.decimals))} {token.symbol})"
+    whole_tokens = value // (10**token.decimals)
+    if whole_tokens < 1:
+        return ""
+    return f" (≈ {whole_tokens:,} {token.symbol})"
 
 
 def _format_param_value(


### PR DESCRIPTION
## Summary
- truncate token-decimal amount hints to whole tokens for values of at least one token
- retain one truncated decimal for sub-token values from 0.1 to under 1, and omit smaller hints
- cover the reported JANE emissions example and sub-token behavior with regression tests

## Testing
- `/srv/monitoring/.venv/bin/python -m pytest -q` (799 passed, 6 skipped)