### PR TITLE
feat: reorder LLM gist report sections (Summary, Analysis, Call Flow, Reference)

### DIFF
--- a/tests/test_llm_report.py
+++ b/tests/test_llm_report.py
@@ -362,17 +362,17 @@ class TestReferenceTable(unittest.TestCase):
 class TestBuildReport(unittest.TestCase):
     def test_sections_in_order(self) -> None:
         report = build_report("Registers a type-2 farm.", "Long analysis.", _add_farms_ctx(), "MEDIUM")
-        self.assertLess(report.index("## Summary"), report.index("## Call Flow"))
+        self.assertLess(report.index("## Summary"), report.index("## Analysis"))
+        self.assertLess(report.index("## Analysis"), report.index("## Call Flow"))
         self.assertLess(report.index("## Call Flow"), report.index("## Reference"))
-        self.assertLess(report.index("## Reference"), report.index("## Analysis"))
 
-    def test_protocol_context_is_deterministic_section_before_analysis(self) -> None:
+    def test_protocol_context_is_deterministic_section_after_call_flow(self) -> None:
         ctx = _add_farms_ctx(protocol_context="- **Farm:** New Silver 2 Senior")
         report = build_report("Updates the rate.", "Long analysis.", ctx, "LOW")
         self.assertIn("## Protocol Context\n\n- **Farm:** New Silver 2 Senior", report)
+        self.assertLess(report.index("## Analysis"), report.index("## Call Flow"))
         self.assertLess(report.index("## Call Flow"), report.index("## Protocol Context"))
         self.assertLess(report.index("## Protocol Context"), report.index("## Reference"))
-        self.assertLess(report.index("## Reference"), report.index("## Analysis"))
 
     def test_metadata_header(self) -> None:
         report = build_report("Summary.", "Analysis.", _add_farms_ctx(label_address=TIMELOCK), "HIGH")

--- a/utils/llm/README.md
+++ b/utils/llm/README.md
@@ -349,6 +349,9 @@ The gist is the artifact a reviewer actually opens, so it carries more than the 
 ## Summary
 Registers a new type-2 farm in FarmRegistry. …
 
+## Analysis
+<the LLM detail>
+
 ## Call Flow
 **From:** [`0x4B17…7c32`](https://etherscan.io/address/0x4B17…)
 
@@ -356,12 +359,9 @@ Registers a new type-2 farm in FarmRegistry. …
    - `uint256 _type`: `2`
    - `address[] _farms`:
      - [`0x79e1…971f`](https://etherscan.io/address/0x79e1…)
-
-## Analysis
-<the LLM detail>
 ```
 
-The report also includes a code-generated `## Reference` table before Analysis:
+The report also ends with a code-generated `## Reference` table after Call Flow:
 
 ```markdown
 | Address | Label | Role | Description |

--- a/utils/llm/report.py
+++ b/utils/llm/report.py
@@ -478,8 +478,8 @@ def build_report(summary: str, detail: str, ctx: ReportContext, risk_tag: str = 
     """Assemble the full markdown gist body.
 
     Sections: metadata header, the Telegram-visible summary (so the gist is
-    self-contained), the deterministic call flow, optional protocol context,
-    a deterministic address reference, and the LLM's analysis.
+    self-contained), the LLM's analysis, the deterministic call flow, optional
+    protocol context, and a deterministic address reference.
 
     Args:
         summary: The authoritative TLDR, risk tag already stripped by the caller.
@@ -499,6 +499,8 @@ def build_report(summary: str, detail: str, ctx: ReportContext, risk_tag: str = 
         sections.append(metadata)
     if summary:
         sections.append(f"## Summary\n\n{summary}")
+    if detail:
+        sections.append(f"## Analysis\n\n{_REDUNDANT_ANALYSIS_HEADING_RE.sub('', detail)}")
     call_flow = format_call_flow(ctx)
     if call_flow:
         sections.append(f"## Call Flow\n\n{call_flow}")
@@ -507,6 +509,4 @@ def build_report(summary: str, detail: str, ctx: ReportContext, risk_tag: str = 
     reference = format_reference_table(ctx)
     if reference:
         sections.append(f"## Reference\n\n{reference}")
-    if detail:
-        sections.append(f"## Analysis\n\n{_REDUNDANT_ANALYSIS_HEADING_RE.sub('', detail)}")
     return "\n\n".join(sections)


### PR DESCRIPTION
## Summary

Reorders the sections of the LLM gist report so the narrative reads first and the deterministic reference material sits at the bottom.

New order in `build_report` (`utils/llm/report.py`):

1. Metadata header (Protocol / Contract / Chain / Risk)
2. `## Summary` — Telegram-visible TLDR
3. `## Analysis` — LLM detail
4. `## Call Flow` — decoded calls with explorer links
5. `## Protocol Context` (when present) — after Call Flow
6. `## Reference` — deterministic address table, now last

## Example

Same report content as https://gist.wavey.info/xAtQzNNwUNwZZBtVGIQ9XJqL re-rendered with the new order: https://gist.wavey.info/msWmcmVvJrJiVyaIAG8yvdJc

## Changes

- `utils/llm/report.py`: moved the `## Analysis` and `## Reference` section assembly; updated the `build_report` docstring
- `tests/test_llm_report.py`: updated ordering assertions; renamed `test_protocol_context_is_deterministic_section_before_analysis` → `..._after_call_flow`
- `utils/llm/README.md`: updated the example report layout and `## Reference` description

## Testing

- `uv run python -m unittest tests.test_llm_report` — 48 tests pass
- `uv run ruff check` / `ruff format --check` — clean