### PR TITLE
fix(safe): route Cap Money Multisig alerts to the CAP channel

### DIFF
--- a/protocols/safe/addresses.py
+++ b/protocols/safe/addresses.py
@@ -35,6 +35,10 @@ PROXY_UPGRADE_SIGNATURES = [
 ]
 
 # Watched non-yearn protocol multisigs. Format: [protocol, network, address, optional label].
+# The protocol field doubles as the Telegram channel key: send_telegram_message resolves
+# TELEGRAM_TOPIC_ID_{protocol.upper()} / TELEGRAM_CHAT_ID_{protocol.upper()}. It must therefore
+# be a legal env-var suffix — a label containing a space (or any non [A-Z0-9_] character) can
+# never resolve and its alerts are silently dropped as "Missing Telegram credentials".
 ALL_SAFE_ADDRESSES = [
     [
         "LIDO",
@@ -106,7 +110,7 @@ ALL_SAFE_ADDRESSES = [
         "sUSDai Admin Safe",
     ],
     [
-        "CAP MONEY",
+        "CAP",
         "mainnet",
         "0xb8FC49402dF3ee4f8587268FB89fda4d621a8793",
         "Cap Money Multisig",

--- a/tests/test_safe_main.py
+++ b/tests/test_safe_main.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import re
 import unittest
 from unittest.mock import Mock, patch
 
@@ -326,3 +327,23 @@ class TestPendingFilterDiag(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSafeProtocolLabels(unittest.TestCase):
+    """The protocol field in ALL_SAFE_ADDRESSES doubles as the Telegram channel key.
+
+    ``send_telegram_message`` resolves credentials via
+    ``TELEGRAM_TOPIC_ID_{protocol.upper()}`` / ``TELEGRAM_CHAT_ID_{protocol.upper()}``.
+    A label that is not a legal env-var suffix can never resolve, and the alert is
+    dropped with only a "Missing Telegram credentials" warning — silent to operators.
+    """
+
+    def test_protocol_labels_are_valid_env_var_suffixes(self):
+        from protocols.safe.addresses import ALL_SAFE_ADDRESSES
+
+        invalid = [entry[0] for entry in ALL_SAFE_ADDRESSES if not re.fullmatch(r"[A-Za-z0-9_]+", entry[0])]
+        self.assertEqual(
+            invalid,
+            [],
+            f"Safe protocol labels must be usable as env-var suffixes, got: {invalid}",
+        )


### PR DESCRIPTION
## Problem

The Cap Money Multisig ([`0xb8FC4940…8793`](https://etherscan.io/address/0xb8FC49402dF3ee4f8587268FB89fda4d621a8793)) is registered in `ALL_SAFE_ADDRESSES` under the protocol label `"CAP MONEY"`.

That field doubles as the Telegram channel key. `send_telegram_message` resolves credentials as:

```python
topic_id = os.getenv(f"TELEGRAM_TOPIC_ID_{protocol.upper()}")
...
chat_id  = os.getenv(f"TELEGRAM_CHAT_ID_{protocol.upper()}")
```

For this entry that is `TELEGRAM_TOPIC_ID_CAP MONEY` — not a legal env-var name, so it can never be set. Every alert for this Safe therefore fell into the missing-credentials branch (`utils/telegram.py:243`) and was discarded:

```python
if not bot_token or not chat_id:
    ...
    logger.warning("Missing Telegram credentials for %s", protocol)
    return
```

**The failure is silent** — a log warning, no alert, no error. This Safe has produced no notifications since it was added in `36fb771`.

## Fix

Relabel to `"CAP"`. That is the intended destination:

- `monitoring.yaml` already declares a `Safe Multisig` monitor — *"Cap Money Multisig queue"* — under the `cap` protocol.
- `TELEGRAM_TOPIC_ID_CAP` exists, and is where the CAP timelock monitor already reports.

`"CAP MONEY"` was the only entry in `ALL_SAFE_ADDRESSES` containing a space, so no other Safe is affected.

## Regression test

Added `TestSafeProtocolLabels::test_protocol_labels_are_valid_env_var_suffixes`, asserting every protocol label matches `[A-Za-z0-9_]+`. Verified it fails against the old value:

```
- ['CAP MONEY']
+ [] : Safe protocol labels must be usable as env-var suffixes, got: ['CAP MONEY']
```

Also documented the constraint in a comment above `ALL_SAFE_ADDRESSES`.

## Why this matters now

Surfaced while reviewing a CAP timelock operation that moves UUPS upgrade rights from this multisig to the Timelock (see yearn/risk-score#460). The multisig retains **92 Access Control roles** after that operation, including 11 selectors on cUSD it can call **with no timelock delay** (`pauseProtocol`, `rescueERC20`, `setWhitelist`, `removeAsset`, …). Its queue is exactly what we want eyes on, and we had none.

## Testing

```
uv run ruff format .   # 176 files left unchanged
uv run ruff check .    # All checks passed!
uv run pytest tests/test_safe_main.py tests/test_monitoring_config.py tests/test_known_addresses.py -q
# 34 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)