### PR TITLE
Resolve bytes32 role names; stop losing reports and warnings

### DIFF
--- a/automation/runner.py
+++ b/automation/runner.py
@@ -33,6 +33,26 @@ TELEGRAM_PROTOCOL: str = "automation"
 _ERROR_TAIL_LINES: int = 4
 _ERROR_TAIL_CHARS: int = 500
 
+# A task can exit 0 while still logging a WARNING/ERROR for something it handled
+# internally — a failed upload, a skipped enrichment, a degraded data source. That
+# output used to land only in the DEBUG dump below, so at the service's default
+# LOG_LEVEL=INFO it was invisible and a broken integration could run unnoticed for
+# days. These lines are re-emitted at INFO instead, capped so a task that logs
+# thousands of warnings can't flood journald.
+_TASK_WARNING_MARKERS: tuple[str, ...] = ("WARNING", "ERROR", "CRITICAL")
+_MAX_SURFACED_WARNINGS: int = 10
+
+
+def _warning_lines(stdout: str | None) -> list[str]:
+    """Return the WARNING/ERROR/CRITICAL lines from a successful task's output.
+
+    Matches the level token produced by ``utils.logger``'s format. Capped at
+    ``_MAX_SURFACED_WARNINGS``; the caller notes how many were suppressed.
+    """
+    if not stdout:
+        return []
+    return [line.rstrip() for line in stdout.splitlines() if any(m in line for m in _TASK_WARNING_MARKERS)]
+
 
 def _error_tail(stdout: str | None, stderr: str | None) -> str | None:
     """Extract a short, human-readable error tail from a failed task's output.
@@ -225,6 +245,21 @@ def _run_task(task: Task, *, profile: Profile, repo_root: Path, dry_run: bool) -
 
     if stdout and stdout.strip():
         logger.debug("task %s output:\n%s", task.name, stdout.rstrip())
+
+    # Surface non-fatal problems from a task that still exited 0 (see above).
+    warnings = _warning_lines(stdout)
+    if warnings:
+        shown = warnings[:_MAX_SURFACED_WARNINGS]
+        suppressed = len(warnings) - len(shown)
+        note = f"\n… {suppressed} more suppressed" if suppressed > 0 else ""
+        logger.info(
+            "task %s exited 0 but logged %d warning(s):\n%s%s",
+            task.name,
+            len(warnings),
+            "\n".join(shown),
+            note,
+        )
+
     logger.info("task %s ok in %.1fs", task.name, duration)
     return TaskResult(
         name=task.name,

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -1149,3 +1149,105 @@ class TestTokenFlows(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestCollectRoleNames(unittest.TestCase):
+    """Tests for _collect_role_names (bytes32 role → name resolution)."""
+
+    GRANT = DecodedCall(
+        function_name="grantRole",
+        signature="grantRole(bytes32,address)",
+        params=[
+            ("bytes32", "0x615a688d53344290b742a2e72e4f187e5b88227c01f9d77ce2406d32f8bd0eda"),
+            ("address", "0xa69e4155F62C097cE92DaAdeF7A925dD40907C0C"),
+        ],
+    )
+
+    @patch("utils.llm.ai_explainer.resolve_role_names")
+    def test_resolves_role_arguments(self, mock_resolve: MagicMock) -> None:
+        from utils.llm.ai_explainer import _collect_role_names, _format_role_name_notes
+
+        mock_resolve.return_value = {self.GRANT.params[0][1]: "RECEIPT_TOKEN_MINTER"}
+        resolved = _collect_role_names([("0xCore", self.GRANT)], chain_id=1)
+
+        self.assertEqual(resolved["0xcore"][self.GRANT.params[0][1]], "RECEIPT_TOKEN_MINTER")
+        self.assertIn("is the role RECEIPT_TOKEN_MINTER", "\n".join(_format_role_name_notes(resolved)))
+
+    @patch("utils.llm.ai_explainer.resolve_role_names")
+    def test_ignores_bytes32_on_non_role_functions(self, mock_resolve: MagicMock) -> None:
+        """A timelock's all-zero predecessor/salt must not become DEFAULT_ADMIN_ROLE."""
+        from utils.llm.ai_explainer import _collect_role_names
+
+        schedule = DecodedCall(
+            function_name="scheduleBatch",
+            signature="scheduleBatch(address[],uint256[],bytes[],bytes32,bytes32,uint256)",
+            params=[("bytes32", "0x" + "00" * 32), ("bytes32", "0x" + "00" * 32), ("uint256", 604800)],
+        )
+        self.assertEqual(_collect_role_names([("0xTimelock", schedule)], chain_id=1), {})
+        mock_resolve.assert_not_called()
+
+    @patch("utils.llm.ai_explainer.resolve_role_names")
+    def test_unresolved_roles_are_omitted(self, mock_resolve: MagicMock) -> None:
+        from utils.llm.ai_explainer import _collect_role_names
+
+        mock_resolve.return_value = {}
+        self.assertEqual(_collect_role_names([("0xCore", self.GRANT)], chain_id=1), {})
+
+    @patch("utils.llm.ai_explainer.resolve_role_names")
+    def test_resolution_failure_never_raises(self, mock_resolve: MagicMock) -> None:
+        from utils.llm.ai_explainer import _collect_role_names
+
+        mock_resolve.side_effect = RuntimeError("etherscan down")
+        self.assertEqual(_collect_role_names([("0xCore", self.GRANT)], chain_id=1), {})
+
+
+class TestUnpublishedReportSpill(unittest.TestCase):
+    """A report that can't reach the gist is written to CACHE_DIR.
+
+    It exists only in memory at that point, so without this the LLM output is
+    lost and a recovery means regenerating it against a chain state that has
+    since moved.
+    """
+
+    @patch("utils.llm.ai_explainer.upload_to_gist", return_value="")
+    def test_failed_upload_spills_report_to_disk(self, _mock_gist: MagicMock) -> None:
+        import os
+
+        from utils.cache import cache_path
+        from utils.llm.ai_explainer import UNPUBLISHED_REPORTS_DIRNAME, Explanation, format_explanation_line
+
+        explanation = Explanation(
+            summary="Grants mint rights.",
+            detail="Full detail here.",
+            report="# Call flow\n\nEverything worth keeping.",
+            title="InfiniFi LongTimelock - MEDIUM",
+        )
+        result = format_explanation_line(explanation)
+        self.assertIn("Couldn't post full report", result)
+
+        directory = cache_path(UNPUBLISHED_REPORTS_DIRNAME)
+        spilled = os.listdir(directory)
+        self.assertEqual(len(spilled), 1)
+        contents = open(os.path.join(directory, spilled[0])).read()
+        self.assertIn("Everything worth keeping.", contents)
+        self.assertIn("InfiniFi LongTimelock - MEDIUM", contents)
+
+    @patch("utils.llm.ai_explainer.upload_to_gist", return_value="https://gist.wavey.info/abc123")
+    def test_successful_upload_spills_nothing(self, _mock_gist: MagicMock) -> None:
+        import os
+
+        from utils.cache import cache_path
+        from utils.llm.ai_explainer import UNPUBLISHED_REPORTS_DIRNAME, Explanation, format_explanation_line
+
+        format_explanation_line(Explanation(summary="ok", detail="d", report="r"))
+        self.assertFalse(os.path.exists(cache_path(UNPUBLISHED_REPORTS_DIRNAME)))
+
+    @patch("utils.llm.ai_explainer.upload_to_gist", return_value="")
+    @patch("utils.llm.ai_explainer.os.makedirs", side_effect=OSError("read-only filesystem"))
+    def test_spill_failure_still_returns_alert_line(self, _mock_mkdir: MagicMock, _mock_gist: MagicMock) -> None:
+        """A failed spill must never take down the alert, which still has the summary."""
+        from utils.llm.ai_explainer import Explanation, format_explanation_line
+
+        result = format_explanation_line(Explanation(summary="Grants mint rights.", detail="d", report="r"))
+        self.assertIn("Grants mint rights.", result)
+        self.assertIn("Couldn't post full report", result)

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from utils.calldata.decoder import DecodedCall
+from utils.calldata.decoder import DecodedCall, decode_calldata
 from utils.erc20_metadata import ERC20Metadata
 from utils.formatting import format_decimal_amount, normalize_token_amount
 from utils.llm.ai_explainer import (
@@ -1152,25 +1152,48 @@ if __name__ == "__main__":
 
 
 class TestCollectRoleNames(unittest.TestCase):
-    """Tests for _collect_role_names (bytes32 role → name resolution)."""
+    """Tests for _collect_role_names (bytes32 role → name resolution).
 
-    GRANT = DecodedCall(
-        function_name="grantRole",
-        signature="grantRole(bytes32,address)",
-        params=[
-            ("bytes32", "0x615a688d53344290b742a2e72e4f187e5b88227c01f9d77ce2406d32f8bd0eda"),
-            ("address", "0xa69e4155F62C097cE92DaAdeF7A925dD40907C0C"),
-        ],
+    The call is built with the real `decode_calldata` rather than hand-written
+    params on purpose: `eth_abi` hands back a bytes32 as 32 raw bytes, and an
+    earlier version of this collector stringified that into a Python repr, so
+    every role silently failed to resolve while string-based tests passed.
+    """
+
+    MINTER_HASH = "0x615a688d53344290b742a2e72e4f187e5b88227c01f9d77ce2406d32f8bd0eda"
+
+    # Real call 0 of tx 0xcfa148be… — grantRole(RECEIPT_TOKEN_MINTER, OutlandVault).
+    GRANT = decode_calldata(
+        "0x2f2ff15d"
+        "615a688d53344290b742a2e72e4f187e5b88227c01f9d77ce2406d32f8bd0eda"
+        "000000000000000000000000a69e4155f62c097ce92daadef7a925dd40907c0c"
     )
+
+    def test_decoded_role_param_is_raw_bytes(self) -> None:
+        """Guards the assumption the collector depends on."""
+        type_str, value = self.GRANT.params[0]
+        self.assertEqual(type_str, "bytes32")
+        self.assertIsInstance(value, bytes)
+
+    @patch("utils.llm.ai_explainer.resolve_role_names")
+    def test_passes_normalized_hash_from_decoded_bytes(self, mock_resolve: MagicMock) -> None:
+        """The hash handed to the resolver must be hex, not a bytes repr."""
+        from utils.llm.ai_explainer import _collect_role_names
+
+        mock_resolve.return_value = {}
+        _collect_role_names([("0xCore", self.GRANT)], chain_id=1)
+
+        passed = mock_resolve.call_args[0][0]
+        self.assertEqual(passed, [self.MINTER_HASH])
 
     @patch("utils.llm.ai_explainer.resolve_role_names")
     def test_resolves_role_arguments(self, mock_resolve: MagicMock) -> None:
         from utils.llm.ai_explainer import _collect_role_names, _format_role_name_notes
 
-        mock_resolve.return_value = {self.GRANT.params[0][1]: "RECEIPT_TOKEN_MINTER"}
+        mock_resolve.return_value = {self.MINTER_HASH: "RECEIPT_TOKEN_MINTER"}
         resolved = _collect_role_names([("0xCore", self.GRANT)], chain_id=1)
 
-        self.assertEqual(resolved["0xcore"][self.GRANT.params[0][1]], "RECEIPT_TOKEN_MINTER")
+        self.assertEqual(resolved["0xcore"][self.MINTER_HASH], "RECEIPT_TOKEN_MINTER")
         self.assertIn("is the role RECEIPT_TOKEN_MINTER", "\n".join(_format_role_name_notes(resolved)))
 
     @patch("utils.llm.ai_explainer.resolve_role_names")
@@ -1181,7 +1204,7 @@ class TestCollectRoleNames(unittest.TestCase):
         schedule = DecodedCall(
             function_name="scheduleBatch",
             signature="scheduleBatch(address[],uint256[],bytes[],bytes32,bytes32,uint256)",
-            params=[("bytes32", "0x" + "00" * 32), ("bytes32", "0x" + "00" * 32), ("uint256", 604800)],
+            params=[("bytes32", b"\x00" * 32), ("bytes32", b"\x00" * 32), ("uint256", 604800)],
         )
         self.assertEqual(_collect_role_names([("0xTimelock", schedule)], chain_id=1), {})
         mock_resolve.assert_not_called()

--- a/tests/test_automation_runner.py
+++ b/tests/test_automation_runner.py
@@ -175,3 +175,51 @@ class TestTelegramSummary(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSuccessfulTaskWarnings(unittest.TestCase):
+    """A task can exit 0 while logging a problem it handled internally.
+
+    Those lines used to land only in the DEBUG dump, so at the service's default
+    LOG_LEVEL=INFO a broken integration could run unnoticed. They are now
+    re-emitted at INFO.
+    """
+
+    @staticmethod
+    def _result(stdout: str):
+        class _Result:
+            returncode = 0
+            stderr = ""
+
+        _Result.stdout = stdout
+        return _Result()
+
+    def _run(self, stdout: str) -> list[str]:
+        profile = _profile([Task(name="timelock-alerts", script="t.py")])
+        with (
+            patch("automation.runner.subprocess.run", return_value=self._result(stdout)),
+            self.assertLogs("automation.runner", level="INFO") as logs,
+        ):
+            run_profile(profile, repo_root=Path("/srv/repo"), dry_run=False, send_digest=False)
+        return logs.output
+
+    def test_warning_from_passing_task_is_surfaced(self):
+        output = "\n".join(
+            [
+                "[2026-09-10 16:09:00] INFO utils.llm: generated summary",
+                "[2026-09-10 16:09:01] WARNING utils.wavey_gist: Failed to upload to Wavey Gist: 400 Client Error",
+            ]
+        )
+        logs = "\n".join(self._run(output))
+        self.assertIn("exited 0 but logged 1 warning(s)", logs)
+        self.assertIn("Failed to upload to Wavey Gist", logs)
+
+    def test_clean_task_logs_no_warning_block(self):
+        logs = "\n".join(self._run("[2026-09-10 16:09:00] INFO utils.llm: all good"))
+        self.assertNotIn("exited 0 but logged", logs)
+        self.assertIn("task timelock-alerts ok", logs)
+
+    def test_surfaced_warnings_are_capped(self):
+        logs = "\n".join(self._run("\n".join(f"WARNING line {i}" for i in range(25))))
+        self.assertIn("exited 0 but logged 25 warning(s)", logs)
+        self.assertIn("15 more suppressed", logs)

--- a/tests/test_llm_report.py
+++ b/tests/test_llm_report.py
@@ -410,3 +410,34 @@ class TestBuildReport(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRoleNameAnnotation(unittest.TestCase):
+    """The call flow names a bytes32 role instead of showing only its digest."""
+
+    MINTER = "0x615a688d53344290b742a2e72e4f187e5b88227c01f9d77ce2406d32f8bd0eda"
+    VAULT = "0xa69e4155F62C097cE92DaAdeF7A925dD40907C0C"
+
+    def _flow(self, role_names: dict[str, str]) -> str:
+        call = DecodedCall(
+            function_name="grantRole",
+            signature="grantRole(bytes32,address)",
+            params=[("bytes32", self.MINTER), ("address", self.VAULT)],
+        )
+        return format_call_flow(
+            _add_farms_ctx(
+                entries=[CallEntry(target=REGISTRY, call=call, param_names=["role", "account"], role_names=role_names)]
+            )
+        )
+
+    def test_resolved_role_is_named(self) -> None:
+        flow = self._flow({self.MINTER: "RECEIPT_TOKEN_MINTER"})
+        self.assertIn("role **RECEIPT_TOKEN_MINTER**", flow)
+        # The digest stays visible so the reader can still verify it.
+        self.assertIn(self.MINTER, flow)
+
+    def test_unresolved_role_renders_unchanged(self) -> None:
+        self.assertNotIn("role **", self._flow({}))
+
+    def test_lookup_is_case_insensitive(self) -> None:
+        self.assertIn("role **RECEIPT_TOKEN_MINTER**", self._flow({self.MINTER.lower(): "RECEIPT_TOKEN_MINTER"}))

--- a/tests/test_llm_report.py
+++ b/tests/test_llm_report.py
@@ -419,10 +419,11 @@ class TestRoleNameAnnotation(unittest.TestCase):
     VAULT = "0xa69e4155F62C097cE92DaAdeF7A925dD40907C0C"
 
     def _flow(self, role_names: dict[str, str]) -> str:
+        # Raw bytes, matching what `decode_calldata` actually stores for bytes32.
         call = DecodedCall(
             function_name="grantRole",
             signature="grantRole(bytes32,address)",
-            params=[("bytes32", self.MINTER), ("address", self.VAULT)],
+            params=[("bytes32", bytes.fromhex(self.MINTER[2:])), ("address", self.VAULT)],
         )
         return format_call_flow(
             _add_farms_ctx(

--- a/tests/test_role_names.py
+++ b/tests/test_role_names.py
@@ -1,0 +1,106 @@
+"""Tests for utils/calldata/role_names.py."""
+
+import unittest
+from unittest.mock import patch
+
+from eth_utils import keccak
+
+from utils.calldata.role_names import (
+    DEFAULT_ADMIN_ROLE,
+    harvest_role_names,
+    normalize_role_hash,
+    resolve_role_names,
+)
+
+# The two roles from InfiniFi's CoreRoles library that a LongTimelock batch
+# granted to a new Outland vault. Neither is an OpenZeppelin standard role, so
+# they only resolve by reading the contract's own source.
+RECEIPT_TOKEN_MINTER = "0x615a688d53344290b742a2e72e4f187e5b88227c01f9d77ce2406d32f8bd0eda"
+RECEIPT_TOKEN_BURNER = "0xc843f0b739b89f713c29d5349e88538222378b9e38ad958b090593af5e3d0fd9"
+
+CORE_ROLES_SOURCE = """
+library CoreRoles {
+    /// @notice the all-powerful role.
+    bytes32 internal constant GOVERNOR = keccak256("GOVERNOR");
+    /// @notice can mint DebtToken arbitrarily
+    bytes32 internal constant RECEIPT_TOKEN_MINTER = keccak256("RECEIPT_TOKEN_MINTER");
+    /// @notice can burn DebtToken tokens
+    bytes32 internal constant RECEIPT_TOKEN_BURNER = keccak256("RECEIPT_TOKEN_BURNER");
+    bytes32 public constant FARM_MANAGER = keccak256("FARM_MANAGER");
+}
+"""
+
+
+class TestNormalizeRoleHash(unittest.TestCase):
+    """Tests for normalize_role_hash."""
+
+    def test_accepts_prefixed_and_mixed_case(self) -> None:
+        self.assertEqual(normalize_role_hash(RECEIPT_TOKEN_MINTER.upper().replace("0X", "0x")), RECEIPT_TOKEN_MINTER)
+
+    def test_accepts_unprefixed(self) -> None:
+        self.assertEqual(normalize_role_hash(RECEIPT_TOKEN_MINTER[2:]), RECEIPT_TOKEN_MINTER)
+
+    def test_rejects_wrong_length_and_non_hex(self) -> None:
+        for bad in ("0xdeadbeef", "", "0x" + "zz" * 32, "not-a-hash"):
+            self.assertEqual(normalize_role_hash(bad), "")
+
+
+class TestHarvestRoleNames(unittest.TestCase):
+    """Tests for harvest_role_names."""
+
+    def test_harvests_internal_and_public_constants(self) -> None:
+        harvested = harvest_role_names(CORE_ROLES_SOURCE)
+        self.assertEqual(harvested[RECEIPT_TOKEN_MINTER], "RECEIPT_TOKEN_MINTER")
+        self.assertEqual(harvested[RECEIPT_TOKEN_BURNER], "RECEIPT_TOKEN_BURNER")
+        self.assertEqual(harvested["0x" + keccak(text="FARM_MANAGER").hex()], "FARM_MANAGER")
+
+    def test_reports_both_names_when_constant_and_preimage_differ(self) -> None:
+        source = 'bytes32 internal constant ADMIN = keccak256("SUPER_ADMIN");'
+        harvested = harvest_role_names(source)
+        self.assertEqual(harvested["0x" + keccak(text="SUPER_ADMIN").hex()], 'ADMIN (keccak256("SUPER_ADMIN"))')
+
+    def test_empty_source_is_safe(self) -> None:
+        self.assertEqual(harvest_role_names(""), {})
+
+
+class TestResolveRoleNames(unittest.TestCase):
+    """Tests for resolve_role_names."""
+
+    def test_static_table_resolves_without_network(self) -> None:
+        minter = "0x" + keccak(text="MINTER_ROLE").hex()
+        resolved = resolve_role_names([minter, DEFAULT_ADMIN_ROLE])
+        self.assertEqual(resolved[minter], "MINTER_ROLE")
+        self.assertEqual(resolved[DEFAULT_ADMIN_ROLE], "DEFAULT_ADMIN_ROLE")
+
+    @patch("utils.source_context.fetch_source")
+    def test_falls_back_to_verified_source(self, mock_fetch: unittest.mock.MagicMock) -> None:
+        mock_fetch.return_value = ("InfiniFiCore", CORE_ROLES_SOURCE)
+
+        resolved = resolve_role_names([RECEIPT_TOKEN_MINTER, RECEIPT_TOKEN_BURNER], chain_id=1, target="0xF6d4")
+        self.assertEqual(resolved[RECEIPT_TOKEN_MINTER], "RECEIPT_TOKEN_MINTER")
+        self.assertEqual(resolved[RECEIPT_TOKEN_BURNER], "RECEIPT_TOKEN_BURNER")
+
+    @patch("utils.source_context.fetch_source")
+    def test_skips_source_lookup_when_static_table_suffices(self, mock_fetch: unittest.mock.MagicMock) -> None:
+        resolve_role_names(["0x" + keccak(text="PAUSER_ROLE").hex()], chain_id=1, target="0xF6d4")
+        mock_fetch.assert_not_called()
+
+    @patch("utils.source_context.fetch_source")
+    def test_unverified_contract_leaves_role_unresolved(self, mock_fetch: unittest.mock.MagicMock) -> None:
+        mock_fetch.return_value = None
+        self.assertEqual(resolve_role_names([RECEIPT_TOKEN_MINTER], chain_id=1, target="0xF6d4"), {})
+
+    @patch("utils.source_context.fetch_source")
+    def test_source_failure_never_raises(self, mock_fetch: unittest.mock.MagicMock) -> None:
+        mock_fetch.side_effect = RuntimeError("etherscan down")
+        self.assertEqual(resolve_role_names([RECEIPT_TOKEN_MINTER], chain_id=1, target="0xF6d4"), {})
+
+    def test_no_chain_context_returns_static_matches_only(self) -> None:
+        self.assertEqual(resolve_role_names([RECEIPT_TOKEN_MINTER]), {})
+
+    def test_garbage_input_returns_empty(self) -> None:
+        self.assertEqual(resolve_role_names(["not-a-hash", ""]), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_role_names.py
+++ b/tests/test_role_names.py
@@ -40,8 +40,11 @@ class TestNormalizeRoleHash(unittest.TestCase):
     def test_accepts_unprefixed(self) -> None:
         self.assertEqual(normalize_role_hash(RECEIPT_TOKEN_MINTER[2:]), RECEIPT_TOKEN_MINTER)
 
+    def test_accepts_raw_bytes(self) -> None:
+        self.assertEqual(normalize_role_hash(bytes.fromhex(RECEIPT_TOKEN_MINTER[2:])), RECEIPT_TOKEN_MINTER)
+
     def test_rejects_wrong_length_and_non_hex(self) -> None:
-        for bad in ("0xdeadbeef", "", "0x" + "zz" * 32, "not-a-hash"):
+        for bad in ("0xdeadbeef", "", "0x" + "zz" * 32, "not-a-hash", b"short", None, 42):
             self.assertEqual(normalize_role_hash(bad), "")
 
 
@@ -72,27 +75,67 @@ class TestResolveRoleNames(unittest.TestCase):
         self.assertEqual(resolved[minter], "MINTER_ROLE")
         self.assertEqual(resolved[DEFAULT_ADMIN_ROLE], "DEFAULT_ADMIN_ROLE")
 
+    @patch("utils.proxy.get_current_implementation", return_value=None)
     @patch("utils.source_context.fetch_source")
-    def test_falls_back_to_verified_source(self, mock_fetch: unittest.mock.MagicMock) -> None:
+    def test_falls_back_to_verified_source(self, mock_fetch, _mock_impl) -> None:
         mock_fetch.return_value = ("InfiniFiCore", CORE_ROLES_SOURCE)
 
         resolved = resolve_role_names([RECEIPT_TOKEN_MINTER, RECEIPT_TOKEN_BURNER], chain_id=1, target="0xF6d4")
         self.assertEqual(resolved[RECEIPT_TOKEN_MINTER], "RECEIPT_TOKEN_MINTER")
         self.assertEqual(resolved[RECEIPT_TOKEN_BURNER], "RECEIPT_TOKEN_BURNER")
 
+    @patch("utils.proxy.get_current_implementation", return_value=None)
+    @patch("utils.source_context.fetch_source")
+    def test_accepts_raw_bytes_from_decoded_calldata(self, mock_fetch, _mock_impl) -> None:
+        """`decode_calldata` yields 32 raw bytes, not hex — the common real case."""
+        mock_fetch.return_value = ("InfiniFiCore", CORE_ROLES_SOURCE)
+
+        raw = bytes.fromhex(RECEIPT_TOKEN_MINTER[2:])
+        resolved = resolve_role_names([raw], chain_id=1, target="0xF6d4")
+        self.assertEqual(resolved[RECEIPT_TOKEN_MINTER], "RECEIPT_TOKEN_MINTER")
+
+    @patch("utils.proxy.get_current_implementation")
+    @patch("utils.source_context.fetch_source")
+    def test_follows_proxy_to_implementation_source(self, mock_fetch, mock_impl) -> None:
+        """Role constants live in the implementation, not the proxy."""
+        proxy, impl = "0xProxy", "0xImpl"
+        mock_impl.return_value = impl
+        mock_fetch.side_effect = lambda _chain, addr: {
+            proxy: ("TransparentUpgradeableProxy", "contract Proxy { fallback() external {} }"),
+            impl: ("InfiniFiCore", CORE_ROLES_SOURCE),
+        }[addr]
+
+        resolved = resolve_role_names([RECEIPT_TOKEN_MINTER], chain_id=1, target=proxy)
+        self.assertEqual(resolved[RECEIPT_TOKEN_MINTER], "RECEIPT_TOKEN_MINTER")
+
+    @patch("utils.proxy.get_current_implementation")
+    @patch("utils.source_context.fetch_source")
+    def test_skips_proxy_hop_when_target_source_resolves(self, mock_fetch, mock_impl) -> None:
+        """A non-proxy target must not pay an RPC call to read an implementation slot."""
+        mock_fetch.return_value = ("InfiniFiCore", CORE_ROLES_SOURCE)
+
+        resolve_role_names([RECEIPT_TOKEN_MINTER], chain_id=1, target="0xF6d4")
+        mock_impl.assert_not_called()
+
     @patch("utils.source_context.fetch_source")
     def test_skips_source_lookup_when_static_table_suffices(self, mock_fetch: unittest.mock.MagicMock) -> None:
         resolve_role_names(["0x" + keccak(text="PAUSER_ROLE").hex()], chain_id=1, target="0xF6d4")
         mock_fetch.assert_not_called()
 
+    @patch("utils.proxy.get_current_implementation", return_value=None)
     @patch("utils.source_context.fetch_source")
-    def test_unverified_contract_leaves_role_unresolved(self, mock_fetch: unittest.mock.MagicMock) -> None:
+    def test_unverified_contract_leaves_role_unresolved(self, mock_fetch, _mock_impl) -> None:
         mock_fetch.return_value = None
         self.assertEqual(resolve_role_names([RECEIPT_TOKEN_MINTER], chain_id=1, target="0xF6d4"), {})
 
     @patch("utils.source_context.fetch_source")
     def test_source_failure_never_raises(self, mock_fetch: unittest.mock.MagicMock) -> None:
         mock_fetch.side_effect = RuntimeError("etherscan down")
+        self.assertEqual(resolve_role_names([RECEIPT_TOKEN_MINTER], chain_id=1, target="0xF6d4"), {})
+
+    @patch("utils.proxy.get_current_implementation", side_effect=RuntimeError("rpc down"))
+    @patch("utils.source_context.fetch_source", return_value=("Proxy", "contract Proxy {}"))
+    def test_proxy_lookup_failure_never_raises(self, _mock_fetch, _mock_impl) -> None:
         self.assertEqual(resolve_role_names([RECEIPT_TOKEN_MINTER], chain_id=1, target="0xF6d4"), {})
 
     def test_no_chain_context_returns_static_matches_only(self) -> None:

--- a/tests/test_wavey_gist.py
+++ b/tests/test_wavey_gist.py
@@ -23,59 +23,66 @@ class TestUploadToGist(unittest.TestCase):
         self.assertEqual(upload_to_gist(""), "")
 
     @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.wavey_gist.requests.post")
-    def test_successful_upload(self, mock_post: MagicMock) -> None:
-        mock_post.return_value = _mock_response()
+    @patch("utils.wavey_gist.request_with_retry")
+    def test_successful_upload(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = _mock_response()
 
         result = upload_to_gist("Some **markdown**", title="Test")
         self.assertEqual(result, "https://gist.wavey.info/abc123")
 
-        payload = mock_post.call_args[1]["json"]
+        payload = mock_request.call_args[1]["json"]
         self.assertEqual(payload["title"], "Test")
         # Wavey Gist now expects a `files` snapshot — the legacy `markdown` field
         # is rejected with HTTP 400. README.md is the preferred primary filename
         # (https://gist.wavey.info/llms.txt).
         self.assertNotIn("markdown", payload)
         self.assertEqual(payload["files"][PRIMARY_FILE_NAME]["content"], "# Test\n\nSome **markdown**")
-        self.assertEqual(mock_post.call_args[1]["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(mock_request.call_args[1]["headers"]["Authorization"], "Bearer test-key")
 
     @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.wavey_gist.requests.post")
-    def test_no_title_sends_raw_content(self, mock_post: MagicMock) -> None:
-        mock_post.return_value = _mock_response()
+    @patch("utils.wavey_gist.request_with_retry")
+    def test_no_title_sends_raw_content(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = _mock_response()
 
         upload_to_gist("Content only")
-        payload = mock_post.call_args[1]["json"]
+        payload = mock_request.call_args[1]["json"]
         self.assertEqual(payload["title"], DEFAULT_GIST_TITLE)
         self.assertEqual(payload["files"][PRIMARY_FILE_NAME]["content"], "Content only")
 
     @patch.dict("utils.wavey_gist.os.environ", {}, clear=True)
-    @patch("utils.wavey_gist.requests.post")
-    def test_missing_api_key_returns_empty(self, mock_post: MagicMock) -> None:
+    @patch("utils.wavey_gist.request_with_retry")
+    def test_missing_api_key_returns_empty(self, mock_request: MagicMock) -> None:
         self.assertEqual(upload_to_gist("x"), "")
-        mock_post.assert_not_called()
+        mock_request.assert_not_called()
 
     @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.wavey_gist.requests.post")
-    def test_missing_url_returns_empty(self, mock_post: MagicMock) -> None:
-        mock_post.return_value = _mock_response(post_json={"id": "abc123"})
+    @patch("utils.wavey_gist.request_with_retry")
+    def test_missing_url_returns_empty(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = _mock_response(post_json={"id": "abc123"})
         self.assertEqual(upload_to_gist("x"), "")
 
     @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.wavey_gist.requests.post")
-    def test_http_error_returns_empty(self, mock_post: MagicMock) -> None:
+    @patch("utils.wavey_gist.request_with_retry")
+    def test_http_error_returns_empty(self, mock_request: MagicMock) -> None:
         # E.g. the legacy `markdown` field — the API now rejects unknown fields
         # with HTTP 400. The function must keep alerting and return "" so the
         # caller can fall back to the in-Telegram summary.
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = requests.HTTPError("400 Client Error")
-        mock_post.return_value = mock_response
-        self.assertEqual(upload_to_gist("x"), "")
+        # `request_with_retry` calls `raise_for_status` internally and re-raises
+        # 4xx without retrying, so the error reaches `upload_to_gist` directly.
+        error_response = MagicMock()
+        error_response.text = "Legacy gist fields are no longer supported."
+        mock_request.side_effect = requests.HTTPError("400 Client Error", response=error_response)
+
+        with self.assertLogs("utils.wavey_gist", level="WARNING") as logs:
+            self.assertEqual(upload_to_gist("x"), "")
+        # The server's explanation must reach the logs — "400 Client Error" alone
+        # gives an operator nothing to act on.
+        self.assertIn("Legacy gist fields are no longer supported.", "\n".join(logs.output))
 
     @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.wavey_gist.requests.post")
-    def test_request_failure_returns_empty(self, mock_post: MagicMock) -> None:
-        mock_post.side_effect = requests.RequestException("Connection error")
+    @patch("utils.wavey_gist.request_with_retry")
+    def test_request_failure_returns_empty(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = requests.RequestException("Connection error")
         self.assertEqual(upload_to_gist("x"), "")
 
 

--- a/utils/calldata/role_names.py
+++ b/utils/calldata/role_names.py
@@ -14,13 +14,16 @@ Two sources recover the pre-image, cheapest first:
   ``bytes32 constant NAME = keccak256("NAME")``. ``fetch_source`` already
   returns every file of a multi-file verified contract concatenated, and it is
   memoized and disk-cached, so harvesting these costs no extra HTTP when source
-  context was already pulled for the same target.
+  context was already pulled for the same target. When the target is a proxy,
+  the implementation's source is consulted too — that is where the constants
+  are declared.
 
 ``DEFAULT_ADMIN_ROLE`` is the one role that is not a pre-image: OpenZeppelin
 defines it as ``bytes32(0)``, so it is mapped explicitly.
 """
 
 import re
+from collections.abc import Iterator
 
 from eth_utils import keccak
 
@@ -71,12 +74,17 @@ _STATIC_ROLES: dict[str, str] = {DEFAULT_ADMIN_ROLE: "DEFAULT_ADMIN_ROLE"}
 _STATIC_ROLES.update({_hash_of(name): name for name in _COMMON_ROLE_NAMES})
 
 
-def normalize_role_hash(value: str) -> str:
+def normalize_role_hash(value: object) -> str:
     """Return ``value`` as a lowercase 0x-prefixed 32-byte hex string, or ``""``.
 
-    Decoded ``bytes32`` params arrive already formatted as ``0x``-prefixed hex,
-    but callers may pass an unprefixed digest or mixed case.
+    ``decode_calldata`` stores raw ``eth_abi`` output, so a real ``bytes32``
+    argument arrives as **32 raw bytes** — not hex. Stringifying those yields a
+    Python repr (``b'aZh\\x8d…'``) that no amount of hex parsing will recover,
+    so ``bytes`` is handled first. Hex strings are still accepted, with or
+    without the ``0x`` prefix and in any casing, for callers that pre-format.
     """
+    if isinstance(value, (bytes, bytearray)):
+        return f"0x{bytes(value).hex()}" if len(value) == 32 else ""
     if not isinstance(value, str):
         return ""
     candidate = value.strip().lower()
@@ -111,15 +119,16 @@ def harvest_role_names(source: str) -> dict[str, str]:
 
 
 def resolve_role_names(
-    role_hashes: list[str], chain_id: int | None = None, target: str | None = None
+    role_hashes: list[object], chain_id: int | None = None, target: str | None = None
 ) -> dict[str, str]:
     """Resolve role hashes to names, consulting the static table then ``target``'s source.
 
     Args:
-        role_hashes: Candidate ``bytes32`` values, in any casing.
+        role_hashes: Candidate ``bytes32`` values as raw bytes or hex strings.
         chain_id: Chain to look ``target`` up on. Source harvesting is skipped
             when either this or ``target`` is missing.
-        target: Contract whose verified source declares the roles.
+        target: Contract whose verified source declares the roles. When it is a
+            proxy, the implementation's source is consulted too.
 
     Returns:
         Mapping of normalized role hash to role name, containing only the
@@ -137,19 +146,41 @@ def resolve_role_names(
         return resolved
 
     try:
-        # Imported lazily: source_context pulls in the Etherscan/web3 stack, and
-        # the static table alone is enough for callers that never hit a chain.
-        from utils.source_context import fetch_source
-
-        record = fetch_source(chain_id, target)
+        for source in _candidate_sources(chain_id, target):
+            for role_hash, name in harvest_role_names(source).items():
+                if role_hash in unresolved:
+                    resolved[role_hash] = name
+            unresolved -= resolved.keys()
+            if not unresolved:
+                break
     except Exception as e:  # noqa: BLE001 - enrichment only; unresolved roles are reported as such
         logger.info("Role-name source lookup failed for %s on chain %s: %s", target, chain_id, e)
-        return resolved
 
-    if record is None:
-        return resolved
-
-    for role_hash, name in harvest_role_names(record[1]).items():
-        if role_hash in unresolved:
-            resolved[role_hash] = name
     return resolved
+
+
+def _candidate_sources(chain_id: int, target: str) -> Iterator[str]:
+    """Yield ``target``'s verified source, then its implementation's if it is a proxy.
+
+    Role constants are declared in the implementation, not the proxy, so a
+    ``grantRole`` on an upgradeable AccessControl contract resolves nothing
+    without this second hop. Mirrors the EIP-1967 fallback already used by
+    :func:`utils.source_context.get_source_context`.
+    """
+    # Imported lazily: source_context pulls in the Etherscan/web3 stack, and the
+    # static table alone is enough for callers that never hit a chain.
+    from utils.source_context import fetch_source
+
+    record = fetch_source(chain_id, target)
+    if record is not None:
+        yield record[1]
+
+    from utils.proxy import get_current_implementation
+
+    impl = get_current_implementation(target, chain_id)
+    if not impl or impl.lower() == target.lower():
+        return
+
+    impl_record = fetch_source(chain_id, impl)
+    if impl_record is not None:
+        yield impl_record[1]

--- a/utils/calldata/role_names.py
+++ b/utils/calldata/role_names.py
@@ -1,0 +1,155 @@
+"""Resolve ``bytes32`` role identifiers to the role names they hash from.
+
+Access-control calls (``grantRole``, ``revokeRole``, ``setRoleAdmin``, …) carry
+their role as an opaque ``bytes32`` that is almost always
+``keccak256("SOME_ROLE_NAME")``. The hash is one-way, so a decoded call on its
+own can only ever show the digest — which is why role grants reach the LLM as
+unidentified parameters and get their severity understated.
+
+Two sources recover the pre-image, cheapest first:
+
+- **Static table** — OpenZeppelin's ``AccessControl``/``TimelockController``
+  roles plus the role names that recur across protocols. Hashed once at import.
+- **Verified source** — protocols declare their roles as
+  ``bytes32 constant NAME = keccak256("NAME")``. ``fetch_source`` already
+  returns every file of a multi-file verified contract concatenated, and it is
+  memoized and disk-cached, so harvesting these costs no extra HTTP when source
+  context was already pulled for the same target.
+
+``DEFAULT_ADMIN_ROLE`` is the one role that is not a pre-image: OpenZeppelin
+defines it as ``bytes32(0)``, so it is mapped explicitly.
+"""
+
+import re
+
+from eth_utils import keccak
+
+from utils.logger import get_logger
+
+logger = get_logger("utils.calldata.role_names")
+
+# `bytes32 [internal|public|private] constant NAME = keccak256("PREIMAGE");`
+# The declared constant name and the hashed string are captured separately —
+# they usually match, but nothing enforces it, and the pre-image is what the
+# hash actually commits to.
+_ROLE_CONSTANT_RE = re.compile(
+    r'bytes32\s+(?:internal\s+|public\s+|private\s+)?constant\s+(\w+)\s*=\s*keccak256\(\s*"([^"]+)"\s*\)'
+)
+
+# OpenZeppelin's AccessControl treats bytes32(0) as the admin of every other
+# role, so it is worth naming even though it has no pre-image.
+DEFAULT_ADMIN_ROLE = "0x" + "00" * 32
+
+_COMMON_ROLE_NAMES = (
+    # OpenZeppelin TimelockController
+    "TIMELOCK_ADMIN_ROLE",
+    "PROPOSER_ROLE",
+    "EXECUTOR_ROLE",
+    "CANCELLER_ROLE",
+    # Recurring across ERC20/ERC721 presets and protocol access control
+    "ADMIN_ROLE",
+    "BURNER_ROLE",
+    "GOVERNOR_ROLE",
+    "GUARDIAN_ROLE",
+    "KEEPER_ROLE",
+    "MANAGER_ROLE",
+    "MINTER_ROLE",
+    "OPERATOR_ROLE",
+    "ORACLE_ROLE",
+    "PAUSER_ROLE",
+    "RELAYER_ROLE",
+    "SNAPSHOT_ROLE",
+    "UPGRADER_ROLE",
+)
+
+
+def _hash_of(name: str) -> str:
+    return "0x" + keccak(text=name).hex()
+
+
+_STATIC_ROLES: dict[str, str] = {DEFAULT_ADMIN_ROLE: "DEFAULT_ADMIN_ROLE"}
+_STATIC_ROLES.update({_hash_of(name): name for name in _COMMON_ROLE_NAMES})
+
+
+def normalize_role_hash(value: str) -> str:
+    """Return ``value`` as a lowercase 0x-prefixed 32-byte hex string, or ``""``.
+
+    Decoded ``bytes32`` params arrive already formatted as ``0x``-prefixed hex,
+    but callers may pass an unprefixed digest or mixed case.
+    """
+    if not isinstance(value, str):
+        return ""
+    candidate = value.strip().lower()
+    if candidate.startswith("0x"):
+        candidate = candidate[2:]
+    if len(candidate) != 64:
+        return ""
+    try:
+        int(candidate, 16)
+    except ValueError:
+        return ""
+    return f"0x{candidate}"
+
+
+def harvest_role_names(source: str) -> dict[str, str]:
+    """Map role hash → declared name for every ``keccak256`` role constant in ``source``.
+
+    Args:
+        source: Solidity source text, typically the concatenated files of a
+            verified contract.
+
+    Returns:
+        Mapping of lowercase 0x-prefixed role hash to the constant's name. The
+        declared name is preferred for display; when it differs from the hashed
+        string, both are reported so the discrepancy stays visible.
+    """
+    resolved: dict[str, str] = {}
+    for declared_name, preimage in _ROLE_CONSTANT_RE.findall(source or ""):
+        label = declared_name if declared_name == preimage else f'{declared_name} (keccak256("{preimage}"))'
+        resolved[_hash_of(preimage)] = label
+    return resolved
+
+
+def resolve_role_names(
+    role_hashes: list[str], chain_id: int | None = None, target: str | None = None
+) -> dict[str, str]:
+    """Resolve role hashes to names, consulting the static table then ``target``'s source.
+
+    Args:
+        role_hashes: Candidate ``bytes32`` values, in any casing.
+        chain_id: Chain to look ``target`` up on. Source harvesting is skipped
+            when either this or ``target`` is missing.
+        target: Contract whose verified source declares the roles.
+
+    Returns:
+        Mapping of normalized role hash to role name, containing only the
+        hashes that resolved. Never raises — an unresolvable role simply stays
+        absent so the caller can report it as unidentified.
+    """
+    wanted = {normalized for h in role_hashes if (normalized := normalize_role_hash(h))}
+    if not wanted:
+        return {}
+
+    resolved = {h: name for h, name in _STATIC_ROLES.items() if h in wanted}
+
+    unresolved = wanted - resolved.keys()
+    if not unresolved or not chain_id or not target:
+        return resolved
+
+    try:
+        # Imported lazily: source_context pulls in the Etherscan/web3 stack, and
+        # the static table alone is enough for callers that never hit a chain.
+        from utils.source_context import fetch_source
+
+        record = fetch_source(chain_id, target)
+    except Exception as e:  # noqa: BLE001 - enrichment only; unresolved roles are reported as such
+        logger.info("Role-name source lookup failed for %s on chain %s: %s", target, chain_id, e)
+        return resolved
+
+    if record is None:
+        return resolved
+
+    for role_hash, name in harvest_role_names(record[1]).items():
+        if role_hash in unresolved:
+            resolved[role_hash] = name
+    return resolved

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -5,14 +5,18 @@ them to an LLM to produce human-readable explanations for governance
 transactions (timelocks and Safe multisigs).
 """
 
+import os
 import re
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal
 from functools import lru_cache
 
 from eth_utils import function_signature_to_4byte_selector, to_checksum_address
 
+from utils.cache import cache_path
 from utils.calldata.decoder import MAX_BYTES_RECURSION_DEPTH, DecodedCall, decode_calldata, try_decode_inner_calldata
+from utils.calldata.role_names import resolve_role_names
 from utils.erc20_metadata import fetch_erc20_metadata
 from utils.formatting import format_decimal_amount, normalize_token_amount
 from utils.impl_diff import diff_implementations, format_impl_diff
@@ -108,9 +112,15 @@ Critical rules for parameter interpretation:
   normalized totalAssets, and configured token targets as verified deterministic facts. Distinguish
   the accounting asset from non-accounting ERC20 targets configured in an escrow whitelist;
   whitelisting proves permission to interact, but not how a token is valued or used downstream.
-- A bytes32 argument the Protocol Context resolves to a keccak256 pre-image IS identified.
-  Name the parameter or role, reason about what it controls, and never call it unknown or
-  unnamed. A bytes32 the section does NOT resolve stays unidentified — say so plainly.
+- A bytes32 argument the Protocol Context or a Role Names section resolves to a keccak256
+  pre-image IS identified. Name the parameter or role, reason about what it controls, and
+  never call it unknown or unnamed. A bytes32 neither section resolves stays unidentified —
+  say so plainly.
+- A Role Names section maps bytes32 role arguments to the role names they hash from, read
+  from the contract's own verified source. Treat those names as verified fact and use them
+  to judge severity: what the role permits drives the verdict, so a role that can mint or
+  burn a token, upgrade code, or move funds is materially more serious than an operational
+  one. Say what the named role actually controls rather than restating the constant.
 - When the Protocol Context states a token distribution mode, use it instead of hedging about
   funding: minting expands supply on claim, transferring draws down the stated balance.
   Compare a new allocation against the prior values the section lists before calling it large.
@@ -164,6 +174,9 @@ _TRAILING_RISK_TAG_RE = re.compile(r"\s*\b(?:" + "|".join(_RISK_TAGS) + r")\b[\s
 # Same match, but capturing, so the report header and gist title can name the risk.
 _TRAILING_RISK_TAG_CAPTURE_RE = re.compile(r"\b(" + "|".join(_RISK_TAGS) + r")\b[\s.]*$", re.IGNORECASE)
 DETAIL_REPORT_TITLE = "AI Transaction Analysis"
+
+# Where reports that failed to reach Wavey Gist are spilled, under CACHE_DIR.
+UNPUBLISHED_REPORTS_DIRNAME = "unpublished-reports"
 
 # JSON Schema for stage 1 (summary + risk_tag only). risk_tag is enum-constrained so
 # the Telegram tag is always valid — no regex extraction or fallback parsing needed.
@@ -432,6 +445,55 @@ def _collect_safety_checks(
                 f"(does not accept ETH) — the call will revert."
             )
     return notes
+
+
+def _collect_role_names(
+    targets_and_calls: list[tuple[str, DecodedCall]],
+    chain_id: int,
+) -> dict[str, dict[str, str]]:
+    """Resolve ``bytes32`` role arguments to names, keyed by lowercased target.
+
+    Only calls whose function name mentions a role (``grantRole``,
+    ``revokeRole``, ``setRoleAdmin``, …) are inspected. That heuristic matters:
+    resolving every ``bytes32`` would label an all-zero ``predecessor`` or
+    ``salt`` — routine in timelock calldata — as ``DEFAULT_ADMIN_ROLE``, which
+    is worse than leaving it unidentified.
+
+    Lookups are grouped by target so each contract's source is consulted once,
+    and that source is already memoized by the source-context fetch, so this is
+    effectively free. Unresolvable roles are deliberately omitted: the system
+    prompt tells the model to call anything absent here unidentified.
+    """
+    hashes_by_target: dict[str, set[str]] = {}
+    for target, decoded in targets_and_calls:
+        if not target or "role" not in (decoded.function_name or "").lower():
+            continue
+        for type_str, value in decoded.params:
+            if type_str == "bytes32":
+                hashes_by_target.setdefault(target, set()).add(str(value))
+
+    if not hashes_by_target:
+        return {}
+
+    def resolve(item: tuple[str, set[str]]) -> tuple[str, dict[str, str]]:
+        target, role_hashes = item
+        try:
+            return target.lower(), resolve_role_names(sorted(role_hashes), chain_id=chain_id, target=target)
+        except Exception as e:  # noqa: BLE001 - enrichment only; never block an explanation
+            logger.info("Role-name resolution failed for %s: %s", target, e)
+            return target.lower(), {}
+
+    resolved = _parallel_map(resolve, list(hashes_by_target.items()))
+    return {target: names for target, names in resolved if names}
+
+
+def _format_role_name_notes(roles_by_target: dict[str, dict[str, str]]) -> list[str]:
+    """Render resolved role names as prompt bullets, one per role."""
+    return [
+        f"{role_hash} on {target} is the role {name}"
+        for target, names in sorted(roles_by_target.items())
+        for role_hash, name in sorted(names.items())
+    ]
 
 
 def _new_impl_verification_note(new_impl: str, chain_id: int) -> str:
@@ -885,6 +947,7 @@ def _build_prompt(
     address_labels: dict[str, str] | None = None,
     param_names_per_call: list[list[str] | None] | None = None,
     safety_notes: list[str] | None = None,
+    role_names: list[str] | None = None,
     description: str = "",
     address_links: str = "",
 ) -> str:
@@ -965,6 +1028,9 @@ def _build_prompt(
 
     if safety_notes:
         parts.append("\n--- Safety Checks ---\n" + "\n".join(f"- {n}" for n in safety_notes))
+
+    if role_names:
+        parts.append("\n--- Role Names ---\n" + "\n".join(f"- {n}" for n in role_names))
 
     risk_anchors = _collect_risk_anchors(decoded_calls)
     if risk_anchors:
@@ -1264,6 +1330,7 @@ def explain_transaction(
     address_labels = _collect_address_labels([(target, decoded)], chain_id)
     param_names = _collect_param_names([(target, decoded)], chain_id)
     safety_notes = _collect_safety_checks([(target, decoded, value)], chain_id)
+    roles_by_target = _collect_role_names([(target, decoded)], chain_id)
     token_flows = _collect_token_flows([(target, decoded)], chain_id, address_labels)
     related_tokens = _collect_related_tokens([(target, decoded)], chain_id)
     protocol_ctx = resolve_protocol_context(protocol, chain_id, [(target, decoded)], address_labels)
@@ -1309,6 +1376,7 @@ def explain_transaction(
         address_labels=address_labels,
         param_names_per_call=param_names,
         safety_notes=safety_notes,
+        role_names=_format_role_name_notes(roles_by_target),
         description=description,
         address_links=address_links,
         related_tokens=format_related_tokens_block(related_tokens, address_labels),
@@ -1323,6 +1391,7 @@ def explain_transaction(
                 call=decoded,
                 value=value,
                 param_names=param_names[0],
+                role_names=roles_by_target.get(target.lower(), {}),
                 amount_token=_sole_token_by_target(related_tokens).get(target.lower()),
             )
         ],
@@ -1438,6 +1507,7 @@ def explain_batch_transaction(
     address_labels = _collect_address_labels(decoded_with_target, chain_id)
     param_names = _collect_param_names(decoded_with_target, chain_id)
     safety_notes = _collect_safety_checks(targets_calls_values, chain_id)
+    roles_by_target = _collect_role_names(decoded_with_target, chain_id)
     token_flows = _collect_token_flows(decoded_with_target, chain_id, address_labels)
     related_tokens = _collect_related_tokens(decoded_with_target, chain_id)
     protocol_ctx = resolve_protocol_context(protocol, chain_id, decoded_with_target, address_labels)
@@ -1464,6 +1534,7 @@ def explain_batch_transaction(
         address_labels=address_labels,
         param_names_per_call=param_names,
         safety_notes=safety_notes,
+        role_names=_format_role_name_notes(roles_by_target),
         description=description,
         address_links=address_links,
         related_tokens=format_related_tokens_block(related_tokens, address_labels),
@@ -1479,6 +1550,7 @@ def explain_batch_transaction(
                 call=call,
                 value=val,
                 param_names=names,
+                role_names=roles_by_target.get(tgt.lower(), {}),
                 amount_token=sole_tokens.get(tgt.lower()),
             )
             for (tgt, call, val), names in zip(targets_calls_values, param_names)
@@ -1512,14 +1584,43 @@ def format_explanation_line(explanation: Explanation) -> str:
     summary, call flow, optional protocol context, and analysis — is uploaded
     to Wavey Gist and linked. The bare detail is published instead when no report
     was built (explanations generated without report context).
+
+    When the upload fails the report is written to disk first. It exists only in
+    memory at this point, and regenerating it means paying for the LLM calls
+    again against a chain state that has since moved — so an unpublished report
+    is spilled to ``CACHE_DIR`` and a later recovery becomes a re-upload rather
+    than a reconstruction.
     """
     line = f"\n🤖 *AI Summary:*\n{escape_markdown(explanation.summary)}"
     if explanation.detail:
-        detail_url = upload_to_gist(
-            explanation.report or explanation.detail, title=explanation.title or DETAIL_REPORT_TITLE
-        )
+        report = explanation.report or explanation.detail
+        title = explanation.title or DETAIL_REPORT_TITLE
+        detail_url = upload_to_gist(report, title=title)
         if detail_url:
             line += f"\n[Full details]({detail_url})"
         else:
+            spilled = _spill_unpublished_report(report, title)
             line += "\n⚠️ Couldn't post full report"
+            if spilled:
+                logger.warning("Unpublished report saved to %s for later recovery", spilled)
     return line
+
+
+def _spill_unpublished_report(report: str, title: str) -> str:
+    """Write a report that failed to upload to ``CACHE_DIR``; return its path or "".
+
+    Best-effort: a failed spill must never take down the alert, which still
+    carries the summary.
+    """
+    try:
+        directory = cache_path(UNPUBLISHED_REPORTS_DIRNAME)
+        os.makedirs(directory, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:60] or "report"
+        path = os.path.join(directory, f"{stamp}-{slug}.md")
+        with open(path, "w") as handle:
+            handle.write(f"# {title}\n\n{report}")
+        return path
+    except OSError as e:
+        logger.warning("Failed to save unpublished report: %s", e)
+        return ""

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -16,7 +16,7 @@ from eth_utils import function_signature_to_4byte_selector, to_checksum_address
 
 from utils.cache import cache_path
 from utils.calldata.decoder import MAX_BYTES_RECURSION_DEPTH, DecodedCall, decode_calldata, try_decode_inner_calldata
-from utils.calldata.role_names import resolve_role_names
+from utils.calldata.role_names import normalize_role_hash, resolve_role_names
 from utils.erc20_metadata import fetch_erc20_metadata
 from utils.formatting import format_decimal_amount, normalize_token_amount
 from utils.impl_diff import diff_implementations, format_impl_diff
@@ -469,8 +469,11 @@ def _collect_role_names(
         if not target or "role" not in (decoded.function_name or "").lower():
             continue
         for type_str, value in decoded.params:
-            if type_str == "bytes32":
-                hashes_by_target.setdefault(target, set()).add(str(value))
+            # `decode_calldata` keeps raw eth_abi output, so this is 32 raw bytes
+            # for a real call. Normalize here rather than stringifying, which
+            # would produce an unparseable Python repr.
+            if type_str == "bytes32" and (role_hash := normalize_role_hash(value)):
+                hashes_by_target.setdefault(target, set()).add(role_hash)
 
     if not hashes_by_target:
         return {}

--- a/utils/llm/report.py
+++ b/utils/llm/report.py
@@ -24,6 +24,7 @@ from utils.calldata.decoder import (
     split_top_level_types,
     try_decode_inner_calldata,
 )
+from utils.calldata.role_names import normalize_role_hash
 from utils.chains import EXPLORER_URLS, Chain
 from utils.related_tokens import RelatedToken
 
@@ -45,6 +46,9 @@ class CallEntry:
     call: DecodedCall
     value: int = 0
     param_names: list[str] | None = None
+    # Role hash → role name for this call's bytes32 role arguments, so the call
+    # flow shows `GOVERNOR` next to the digest instead of the digest alone.
+    role_names: dict[str, str] = field(default_factory=dict)
     # The single ERC20 this call's target is denominated in, when exactly one
     # resolved. Used to annotate raw amounts with a human-readable figure.
     amount_token: RelatedToken | None = None
@@ -279,14 +283,23 @@ def _format_params(
     indent: str,
     depth: int = 0,
     token: "RelatedToken | None" = None,
+    role_names: dict[str, str] | None = None,
 ) -> list[str]:
-    """Render a call's parameters as an indented markdown bullet list."""
+    """Render a call's parameters as an indented markdown bullet list.
+
+    A ``bytes32`` that ``role_names`` resolves is annotated with its role name.
+    Scalars render to exactly one line, so the annotation is appended to the
+    line just produced; composites are left alone.
+    """
     lines: list[str] = []
     for i, (type_str, value) in enumerate(call.params):
         name = param_names[i] if param_names is not None and i < len(param_names) else None
-        lines.extend(
-            _render_param(_param_label(type_str, name), type_str, value, chain_id, labels, indent, depth, token)
-        )
+        rendered = _render_param(_param_label(type_str, name), type_str, value, chain_id, labels, indent, depth, token)
+        if role_names and type_str == "bytes32" and len(rendered) == 1:
+            role = role_names.get(normalize_role_hash(str(value)))
+            if role:
+                rendered = [f"{rendered[0]} — role **{role}**"]
+        lines.extend(rendered)
     return lines
 
 
@@ -310,7 +323,13 @@ def format_call_flow(ctx: ReportContext) -> str:
         if entry.value > 0:
             lines.append(f"   - **ETH value:** `{entry.value / 1e18:.6f}` ETH")
         param_lines = _format_params(
-            entry.call, ctx.chain_id, ctx.labels, entry.param_names, indent="   ", token=entry.amount_token
+            entry.call,
+            ctx.chain_id,
+            ctx.labels,
+            entry.param_names,
+            indent="   ",
+            token=entry.amount_token,
+            role_names=entry.role_names,
         )
         lines.extend(param_lines or ["   - _no inputs_"])
         lines.append("")

--- a/utils/llm/report.py
+++ b/utils/llm/report.py
@@ -296,7 +296,7 @@ def _format_params(
         name = param_names[i] if param_names is not None and i < len(param_names) else None
         rendered = _render_param(_param_label(type_str, name), type_str, value, chain_id, labels, indent, depth, token)
         if role_names and type_str == "bytes32" and len(rendered) == 1:
-            role = role_names.get(normalize_role_hash(str(value)))
+            role = role_names.get(normalize_role_hash(value))
             if role:
                 rendered = [f"{rendered[0]} — role **{role}**"]
         lines.extend(rendered)

--- a/utils/wavey_gist.py
+++ b/utils/wavey_gist.py
@@ -4,15 +4,33 @@ import os
 
 import requests
 
+from utils.http_client import request_with_retry
 from utils.logger import get_logger
 
 logger = get_logger("utils.wavey_gist")
+
+# How much of an error response body to log. Wavey Gist explains rejections in
+# the body ("Legacy gist fields are no longer supported."), and `raise_for_status`
+# throws that away — leaving only "400 Client Error" in the logs, which says
+# nothing about what to fix.
+_ERROR_BODY_CHARS: int = 300
 
 WAVEY_GIST_API_URL = "https://api.wavey.info/api/v1/gists"
 DEFAULT_GIST_TITLE = "Monitoring Details"
 # Wavey Gist picks `README.md` as the primary file when present, so the rendered
 # page opens with our content. See https://gist.wavey.info/llms.txt.
 PRIMARY_FILE_NAME = "README.md"
+
+
+def _response_detail(error: Exception) -> str:
+    """Return the server's error body as a log suffix, or "" when unavailable."""
+    response = getattr(error, "response", None)
+    body = (getattr(response, "text", "") or "").strip()
+    if not body:
+        return ""
+    if len(body) > _ERROR_BODY_CHARS:
+        body = body[:_ERROR_BODY_CHARS] + "…"
+    return f" — response body: {body}"
 
 
 def upload_to_gist(content: str, title: str = "") -> str:
@@ -44,16 +62,18 @@ def upload_to_gist(content: str, title: str = "") -> str:
     }
 
     try:
-        response = requests.post(
+        # Retries transient 5xx/timeouts and never retries a 4xx, so a contract
+        # change like the legacy-payload rejection still fails fast.
+        response = request_with_retry(
+            "POST",
             WAVEY_GIST_API_URL,
             json=payload,
             headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
             timeout=10,
         )
-        response.raise_for_status()
         body = response.json()
     except (requests.RequestException, ValueError) as e:
-        logger.warning("Failed to upload to Wavey Gist: %s", e)
+        logger.warning("Failed to upload to Wavey Gist: %s%s", e, _response_detail(e))
         return ""
 
     url = body.get("url", "")
@@ -62,4 +82,4 @@ def upload_to_gist(content: str, title: str = "") -> str:
         return ""
 
     logger.info("Uploaded gist to %s", url)
-    return url
+    return str(url)


### PR DESCRIPTION
Three fixes from one postmortem. An InfiniFi LongTimelock batch ([tx `0xcfa148be…196e`](https://etherscan.io/tx/0xcfa148be8e66cf358cb484be38410cbc5827877e5b3c62f7804d76d78a36196e), alert #901) wired a new Outland vault into core and granted it **unbounded mint and burn of iUSD**. The alert summarized that as *"two roles … whose names are not resolvable from the calldata"* and couldn't post its full report. Each of those was a separate gap.

## 1. Resolve `bytes32` role names (`feat(llm)`)

The system prompt already specified the behavior:

> *"A bytes32 argument the Protocol Context resolves to a keccak256 pre-image IS identified… A bytes32 the section does NOT resolve stays unidentified — say so plainly."*

The model followed that exactly. Nothing in the codebase ever populated role pre-images, so **every** `grantRole(bytes32,address)` was structurally guaranteed to come out unidentified, with severity understated to match.

New `utils/calldata/role_names.py` recovers the pre-image from:
- a static table of OpenZeppelin / commonly recurring roles, and
- `keccak256("NAME")` constants harvested from the target's verified source.

The second costs **no extra HTTP**: `fetch_source` is already memoized and disk-cached by the source-context fetch, and returns every file of a multi-file contract concatenated — which is where libraries like InfiniFi's `CoreRoles` live. The source needed to resolve both roles was already sitting in `/srv/cache/source-cache/` when alert #901 was generated.

Verified end-to-end against that transaction:

```
0x615a688d…0eda on 0xf6d4…5490 is the role RECEIPT_TOKEN_MINTER
0xc843f0b7…0fd9 on 0xf6d4…5490 is the role RECEIPT_TOKEN_BURNER
```

Only functions whose name mentions a role are inspected. Resolving every `bytes32` would label a timelock's all-zero `predecessor`/`salt` as `DEFAULT_ADMIN_ROLE` — worse than leaving it unidentified — so that's covered by a test.

Resolved names feed both the prompt (new Role Names section, with guidance to judge severity by what the role actually permits) and the gist call flow, which now shows the name beside the digest rather than the digest alone.

## 2. Surface warnings from tasks that exit 0 (`fix(automation)`)

`runner.py` logged a passing task's stdout at DEBUG, and the service runs `LOG_LEVEL=INFO`. When Wavey Gist broke, the task logged the 400 and exited 0, so journald showed only `task timelock-alerts ok in 249.6s` — the broken integration ran unnoticed until someone read the Telegram body.

WARNING/ERROR/CRITICAL lines from a passing task are now re-emitted at INFO, capped at 10 with a suppressed-count note. The DEBUG dump is unchanged.

## 3. Stop discarding diagnostics and reports (`fix(wavey-gist)` + `feat(llm)`)

- `raise_for_status()` threw away the response body, so logs showed `400 Client Error` while Wavey Gist had actually said *"Legacy gist fields are no longer supported."* Error bodies are now logged (capped at 300 chars).
- The upload used a bare `requests.post` with no retry. It now uses `utils.http_client.request_with_retry`, which backs off on 5xx/timeouts and deliberately does **not** retry 4xx, so a rejected payload still fails fast.
- The report existed only in memory during `format_explanation_line`, so a failed upload destroyed it permanently — which is why recovering #901 meant reconstructing rather than re-publishing. Failed reports now spill to `CACHE_DIR/unpublished-reports/`. Best-effort: if the spill fails, the alert still goes out with its summary.

## Testing

`879 passed, 6 skipped` · `ruff check` and `ruff format` clean · `mypy` introduces no new errors in the touched files (the repo-wide `Duplicate module named "main"` failure is pre-existing on `main`).

New coverage: role hash normalization/harvesting/resolution incl. unverified-contract and API-failure paths; the non-role-`bytes32` guard; runner warning surfacing and its cap; report role annotation; and the spill path incl. its failure mode.

## Notes for review

- Draft because the role-name change alters LLM prompt content — worth a look at the Role Names wording in `SYSTEM_INSTRUCTIONS` before this affects live alert severity.
- Adding Monad (chain 143) to `utils/chains.py` was considered and deliberately left out; it's a product call, not a defect, and nothing here needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)