### PR TITLE
fix(timelock): record alerts under website protocol keys

### DIFF
--- a/protocols/timelock/timelock_alerts.py
+++ b/protocols/timelock/timelock_alerts.py
@@ -34,6 +34,16 @@ CACHE_KEY = "TIMELOCK_LAST_TS"
 # TELEGRAM_BOT_TOKEN_YEARN_TIMELOCK_INTERNAL / TELEGRAM_CHAT_ID_YEARN_TIMELOCK_INTERNAL.
 YEARN_TIMELOCK_INTERNAL_PROTOCOL = "YEARN_TIMELOCK_INTERNAL"
 
+# TimelockConfig.protocol is the Telegram routing key (TELEGRAM_TOPIC_ID_<KEY>),
+# but the alert store must use the protocol key the website queries
+# (`GET /v1/alerts?protocol=<key>`, exact match) or the alert never shows on the
+# protocol's page. Keys default to the lowercased routing key; list exceptions here.
+ALERT_HISTORY_PROTOCOLS: dict[str, str] = {
+    "YEARN_TIMELOCK": "yearn",
+    "RTOKEN": "ethplus",
+    "LRT": "pegs",
+}
+
 
 @dataclass(frozen=True)
 class TimelockConfig:
@@ -84,6 +94,11 @@ TIMELOCKS: dict[tuple[str, int], TimelockConfig] = {(t.address, t.chain_id): t f
 SKIP_AI_SUMMARY_PROTOCOLS: frozenset[str] = frozenset({"AAVE", "COMP", "LIDO", "FLUID"})
 
 _logger = get_logger("timelock_alerts")
+
+
+def alert_history_protocol(routing_protocol: str) -> str:
+    """Return the protocol key the alert store and website use for a routing key."""
+    return ALERT_HISTORY_PROTOCOLS.get(routing_protocol, routing_protocol.lower())
 
 
 def http_json(url: str, method: str = "GET", body: dict | None = None, headers: dict | None = None) -> dict | None:
@@ -571,9 +586,12 @@ def process_events(events: list[dict], use_cache: bool) -> None:
         if current_parts:
             chunks.append(separator.join(current_parts))
 
+        # The internal mirror keeps its own key so the website doesn't list every
+        # Yearn timelock alert twice.
+        origin_protocol = None if protocol == YEARN_TIMELOCK_INTERNAL_PROTOCOL else alert_history_protocol(protocol)
         for chunk in chunks:
             try:
-                send_telegram_message(chunk, protocol)
+                send_telegram_message(chunk, protocol, origin_protocol=origin_protocol)
             except Exception:
                 _logger.exception("Failed to send Telegram alert for protocol %s", protocol)
                 all_sent = False

--- a/tests/test_timelock_alerts.py
+++ b/tests/test_timelock_alerts.py
@@ -4,8 +4,17 @@ import unittest
 import unittest.mock
 from unittest.mock import patch
 
-from protocols.timelock.timelock_alerts import TIMELOCKS, TimelockConfig, build_alert_message
+from protocols.timelock.timelock_alerts import (
+    TIMELOCKS,
+    YEARN_TIMELOCK_INTERNAL_PROTOCOL,
+    TimelockConfig,
+    alert_history_protocol,
+    build_alert_message,
+    process_events,
+)
 from utils.telegram import MAX_MESSAGE_LENGTH
+
+YEARN_TIMELOCK_ADDRESS = "0x88ba032be87d5ef1fbe87336b7090767f367bf73"
 
 
 def test_3jane_seven_day_timelock_is_monitored() -> None:
@@ -13,6 +22,26 @@ def test_3jane_seven_day_timelock_is_monitored() -> None:
 
     assert timelock.protocol == "3JANE"
     assert timelock.label == "3Jane 7d TimelockController"
+
+
+def test_alert_history_protocol_matches_website_keys() -> None:
+    assert alert_history_protocol("YEARN_TIMELOCK") == "yearn"
+    assert alert_history_protocol("RTOKEN") == "ethplus"
+    assert alert_history_protocol("COMP") == "comp"
+    assert alert_history_protocol("3JANE") == "3jane"
+    assert alert_history_protocol("CAP") == "cap"
+
+
+@patch("protocols.timelock.timelock_alerts.send_telegram_message")
+@patch("protocols.timelock.timelock_alerts.build_alert_message", return_value="msg")
+def test_yearn_timelock_alert_recorded_under_yearn(_mock_build: object, mock_send: unittest.mock.MagicMock) -> None:
+    """Routing stays on YEARN_TIMELOCK, but the stored protocol must be `yearn` for the website."""
+    event = _make_event(id="1", timelockAddress=YEARN_TIMELOCK_ADDRESS)
+
+    process_events([event], use_cache=False)
+
+    calls = {c.args[1]: c.kwargs["origin_protocol"] for c in mock_send.call_args_list}
+    assert calls == {"YEARN_TIMELOCK": "yearn", YEARN_TIMELOCK_INTERNAL_PROTOCOL: None}
 
 
 def _make_event(


### PR DESCRIPTION
## Problem

Timelock alerts never appear on https://curation.yearn.fi/monitoring/ protocol pages (e.g. `/monitoring/yearn/`).

`timelock_alerts.py` passes its uppercase Telegram routing key (`YEARN_TIMELOCK`, `CAP`, `3JANE`, `INFINIFI`, `AAVE`, …) to `send_telegram_message`, which also stores it as the alert's `protocol`. The website queries `GET /v1/alerts?protocol=<key>&source=protocol` with an exact-match key taken from each page's `data-api-protocol` (`yearn`, `cap`, `3jane`, `comp`, `ethplus`, …), so every timelock alert was filtered out.

Live API confirms it: `protocol=YEARN_TIMELOCK` returns the missing Yearn timelock alerts; `protocol=yearn` does not.

## Fix

- Telegram routing is unchanged.
- Alerts are now stored under the website key via the existing `origin_protocol` parameter: the lowercased routing key, with exceptions `YEARN_TIMELOCK → yearn`, `RTOKEN → ethplus`, `LRT → pegs`.
- The `YEARN_TIMELOCK_INTERNAL` mirror keeps its own key so the Yearn page doesn't show each alert twice.
- Tests for the key mapping and for how Yearn alerts are stored.

## Open questions / follow-ups

- **`LRT → pegs` is a guess.** The `lrt-pegs` (and `maple`) pages currently have no alert table. `pegs` matches what the lrt-pegs scripts use.
- **Past alerts are not moved.** To show them, run on the production `monitoring.db` (not run):
  ```sql
  UPDATE alert_events
  SET protocol = CASE protocol WHEN 'YEARN_TIMELOCK' THEN 'yearn' WHEN 'RTOKEN' THEN 'ethplus'
                               WHEN 'LRT' THEN 'pegs' ELSE lower(protocol) END
  WHERE source = 'protocol'
    AND protocol IN ('YEARN_TIMELOCK','CAP','RTOKEN','LRT','INFINIFI','AAVE','COMP','FLUID','LIDO','MAPLE','STRATA','3JANE');
  ```
- **`/monitoring/timelock/` stays empty** for `source=protocol`: it queries `protocol=timelock`, and an alert has one protocol key. Showing alerts there too needs a frontend/API change (multi-key filter or a metadata tag).

## Testing

- `pytest tests/test_timelock_alerts.py tests/test_monitoring_config.py`: 21 passed
- `ruff check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)